### PR TITLE
Add Python 2 compatibility

### DIFF
--- a/naivehtmlparser.py
+++ b/naivehtmlparser.py
@@ -3,7 +3,10 @@
 Python 3.x HTMLParser extension with ElementTree support.
 """
 
-from html.parser import HTMLParser
+try:
+    from html.parser import HTMLParser
+except:
+    from HTMLParser import HTMLParser
 from xml.etree import ElementTree
 
 


### PR DESCRIPTION
By using the HTMLParser class

There's probably a better way to do this, by this works, `HTMLParser` is distributed by default with Python 2
